### PR TITLE
Remove dependency target for builds and add go test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ CTL_DEST=$(DST_DIR)/gladius-controld$(BINARY_SUFFIX)
 
 # commands for go
 GOBUILD=go build
-
+GOTEST=go test
 ##
 # MAKE TARGETS
 ##
@@ -52,23 +52,23 @@ dependencies:
 	glide install
 
 # build steps
-test-cli: dependencies $(CLI_SRC)
-	echo "tests not implemented yet"
+test-cli: $(CLI_SRC)
+	$(GOTEST) $(CLI_SRC)
 
 cli: test-cli
 	$(GOBUILD) -o $(CLI_DEST) $(CLI_SRC)
 
-test-networkd: dependencies $(NET_SRC)
-	echo "tests not implemented yet"
+test-networkd: $(NET_SRC)
+	$(GOTEST) $(NET_SRC)
 
 networkd: test-networkd
 	$(GOBUILD) -o $(NET_DEST) $(NET_SRC)
 
 # Uncomment when controld is implemented
 # test-controld: dependencies $(CTL_SRC)
-# 	echo "tests not implemented yet"
+# 	$(GOTEST) $(CTL_SRC)
 #
 # controld: test-controld
 # 	$(GOBUILD) -o $(CTL_DEST) $(CTL_SRC)
 
-build-all: dependencies cli networkd #controld
+build-all: cli networkd #controld

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ NET_DEST=$(DST_DIR)/gladius-networkd$(BINARY_SUFFIX)
 CTL_DEST=$(DST_DIR)/gladius-controld$(BINARY_SUFFIX)
 
 # commands for go
-GOBUILD=GOPATH=$(GOPATH) go build
+GOBUILD=go build
 
 ##
 # MAKE TARGETS

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ To test and build the gladius binaries you need go, glide and the make on your m
 - *Mac Users:* Install xcode for make `xcode-select --install`
 - *Windows Users:* Install [Linux Subsystem](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
 
+### Install dependencies
+We use [glide](https://github.com/Masterminds/glide) to manage the go dependencies.
+To install the dependencies you need to executethe `dependencies` target.
+
+```shell
+# install depdencies for the project with glide
+make dependencies
+``` 
+
 ### Build
 To build all binaries for your current os and architecture simply execute `make`.
 After the build process you will find all binaries in *./build/*.


### PR DESCRIPTION
1. Remove the gopath instruction for the go build command (unnecessary since e7c5171adebe2b36ced96d87fa41ceb043cac8c2 )
2. add execution of go test to all test targets
3. remove 'dependencies' target from build-all and test targets.
4. Add instruction to readme to execute `make dependencies` first