### PR TITLE
make makefile work with windows (mostly)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -64,8 +64,8 @@
     "node",
     "utils"
   ]
-  revision = "20fd1cea5b978667882deee44cbbc981777bff54"
-  version = "0.2.4"
+  revision = "136f24a5e97844aedb8de0888885cd03e813c184"
+  version = "0.2.5"
 
 [[projects]]
   name = "github.com/gladiusio/gladius-controld"
@@ -331,7 +331,7 @@
   branch = "master"
   name = "golang.org/x/net"
   packages = ["websocket"]
-  revision = "57065200b4b034a1c8ad54ff77069408c2218ae6"
+  revision = "8e0cdda24ed423affc8f35c241e5e9b16180338e"
 
 [[projects]]
   branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,10 @@ endif
 ifeq ($(OS),Windows_NT)
 dependencies:
 	dep ensure
-	dep ensure
 	rem the go-etherum installation on windows fails atm
 	rem go get github.com/ethereum/go-ethereum
-	rem xcopy ^
-		"%GOPATH%\\src\\github.com\\ethereum\\go-ethereum\\crypto\\secp256k1\\libsecp256k1" ^
+	rem xcopy \
+		"%GOPATH%\\src\\github.com\\ethereum\\go-ethereum\\crypto\\secp256k1\\libsecp256k1" \
 		"vendor\\github.com\\ethereum\\go-ethereum\\crypto\\secp256k1\\"
 
 else

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The full suite of Gladius binaries ([controld](https://github.com/gladiusio/glad
 
 - Run this in the terminal
 
-  `curl https://raw.githubusercontent.com/gladiusio/gladius-node/master/installers/install.sh | sudo bash`
+  `curl -s https://raw.githubusercontent.com/gladiusio/gladius-node/master/installers/install.sh | sudo bash`
 
 - Download Profile UI (Optional)
   - [macOS](https://github.com/gladiusio/gladius-node/releases/download/0.2.0/Gladius-darwin-x64.zip)

--- a/ops/release-all.sh
+++ b/ops/release-all.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 RELEASE_DIR="./build/release"
-TAG=0.2.1
+TAG=0.2.2
 
 mkdir -p $RELEASE_DIR
 


### PR DESCRIPTION
this pr makes the makefile options work with windows machines (except for the xgo dependencies step.

it also removes the release target from windows based machines