### PR TITLE
Dockerfile and docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,13 +90,13 @@ DOCKER_RELEASE ?= $(shell git describe --abbrev=0 --tags)
 ifeq ($(OS),Windows_NT)
 	DOCKER_OS ?= windows
 	ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
-		DOCKER_ARCH = amd64
+		DOCKER_ARCH ?= amd64
 	else
 		ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
-			DOCKER_ARCH = amd64	
+			DOCKER_ARCH ?= amd64	
 		endif
 		ifeq ($(PROCESSOR_ARCHITECTURE),x86)
-			DOCKER_ARCH = 386
+			DOCKER_ARCH ?= 386
 		endif
 	endif
 else
@@ -104,20 +104,20 @@ else
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Darwin)
 		DOCKER_OS ?= linux
-		DOCKER_ARCH = amd64
+		DOCKER_ARCH ?= amd64
 	endif
 	# if we run linux we need to check which processor arch we run on
 	ifeq ($(UNAME_S),Linux)
 		DOCKER_OS ?= linux
 		UNAME_R := $(shell uname -r)
 		ifneq (,$(findstring amd64,$(UNAME_R)))
-    		DOCKER_ARCH = amd64
+    		DOCKER_ARCH ?= amd64
     	endif
     	ifneq (,$(findstring i386,$(UNAME_R)))
-    		DOCKER_ARCH = 386
+    		DOCKER_ARCH ?= 386
     	endif
     	ifneq (,$(findstring arm,$(UNAME_R)))
-    		DOCKER_ARCH = arm
+    		DOCKER_ARCH ?= arm
     	endif
     endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,8 @@ build-all: cli networkd controld
 # you must specify the release tag for the build process
 # make docker DOCKER_RELEASE=0.2.2
 DOCKER_IMAGE ?= gladiusio/gladius-node
-DOCKER_RELEASE ?= $(shell git describe --abbrev=0 --tags)
+DOCKER_RELEASE_COMMIT := $(shell git rev-list --tags --max-count=1)
+DOCKER_RELEASE ?= $(shell git describe --tags ${DOCKER_RELEASE_COMMIT})
 
 # get the cpu architecture to choose the correct dockerfile for the build
 # https://stackoverflow.com/questions/714100/os-detecting-makefile

--- a/Makefile
+++ b/Makefile
@@ -78,3 +78,70 @@ controld: test-controld
 	$(GOBUILD) -o $(CTL_DEST) $(CTL_SRC)
 
 build-all: cli networkd controld
+
+# docker build based on releases
+# you must specify the release tag for the build process
+# make docker DOCKER_RELEASE=0.2.2
+DOCKER_IMAGE ?= gladiusio/gladius-node
+DOCKER_RELEASE ?= $(shell git describe --abbrev=0 --tags)
+
+# get the cpu architecture to choose the correct dockerfile for the build
+# https://stackoverflow.com/questions/714100/os-detecting-makefile
+ifeq ($(OS),Windows_NT)
+	DOCKER_OS ?= windows
+	ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
+		DOCKER_ARCH = amd64
+	else
+		ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+			DOCKER_ARCH = amd64	
+		endif
+		ifeq ($(PROCESSOR_ARCHITECTURE),x86)
+			DOCKER_ARCH = 386
+		endif
+	endif
+else
+	# check if we are running mac os x - by default we will use amd64 in thise case (docker for mac is a linux 64bit machine)
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		DOCKER_OS ?= linux
+		DOCKER_ARCH = amd64
+	endif
+	# if we run linux we need to check which processor arch we run on
+	ifeq ($(UNAME_S),Linux)
+		DOCKER_OS ?= linux
+		UNAME_R := $(shell uname -r)
+		ifneq (,$(findstring amd64,$(UNAME_R)))
+    		DOCKER_ARCH = amd64
+    	endif
+    	ifneq (,$(findstring i386,$(UNAME_R)))
+    		DOCKER_ARCH = 386
+    	endif
+    	ifneq (,$(findstring arm,$(UNAME_R)))
+    		DOCKER_ARCH = arm
+    	endif
+    endif
+endif
+docker_image:
+	docker build --tag ${DOCKER_IMAGE}:${DOCKER_RELEASE} \
+		--build-arg gladius_release=${DOCKER_RELEASE} \
+		--build-arg gladius_os=${DOCKER_OS} \
+		--build-arg gladius_architecture=${DOCKER_ARCH} \
+		-f ./ops/Dockerfile ./ops
+	
+docker_push: docker_image
+	docker push ${DOCKER_IMAGE}:${DOCKER_RELEASE}
+
+# execute local docker compose for testing
+docker_compose:
+	# build docker compose image
+	docker-compose -p gladius -f ops/docker-compose.yml build \
+		--build-arg gladius_release=${DOCKER_RELEASE} \
+		--build-arg gladius_os=${DOCKER_OS} \
+		--build-arg gladius_architecture=${DOCKER_ARCH} \
+		
+	# start services
+	docker-compose -p gladius -f ops/docker-compose.yml up -d
+
+# cleanup local docker compose
+docker_compose_cleanup:
+	docker-compose -p gladius -f ops/docker-compose.yml rm -fsv

--- a/README.md
+++ b/README.md
@@ -206,3 +206,53 @@ GOOS=windows GOARCH=amd64 make
 # build for linux 32bit
 GOOS=linux GOARCH=386 make
 ```
+
+---
+
+## Docker
+You can use the provided Dockerfile and docker-compose file to run the gladius networkd and controld as docker containers on your machine. The setup is tested on docker for mac and linux boxes, not yet on arm machines.
+
+### build and publish an image
+You can build and publish a docker gladius image to a registry with the two make targets
+```bash
+# create a docker image `gladiusio/gladius-node with the latest binary (from the most current release tag in git)
+make docker_image
+# - or create a docker image with a specific release tag and image name
+make docker_image DOCKER_RELEASE=0.2.2 DOCKER_IMAGE=sebastianhutter/gladius-node
+
+# push the image to the docker registry
+make docker_push
+# or push a specific image
+make docker_push DOCKER_IMAGE=sebastianhutter/gladius-node
+```
+
+### use docker-compose to run gladius-controld and networkd
+You can also use the provided docker compose file to build the images and run them locally
+```bash
+# run docker compose with the latest release
+make docker_compose
+
+# run docker compose with a specific gladius release
+make docker_compose DOCKER_RELEASE=0.2.2
+```
+### use docker to run the gladius cli
+The image also provides the gladius cli.
+```bash
+# build the docker image sebastianhutter/gladius-node with releasde 0.2.2 
+make docker_image DOCKER_RELEASE=0.2.2 DOCKER_IMAGE=sebastianhutter/gladius-node
+# use the image to run the cli
+docker run --rm -ti sebastianhutter/gladius-node:0.2.2 gladius --help
+```
+
+### cleanup
+To remove the created docker containers, volumes and network you can execute the docker_compose_cleanup target
+```bash
+make docker_compose_cleanup
+```
+
+### Persistent Volumes
+The docker images exposes three volumes ${GLADIUSBASE}/content, ${GLADIUSBASE}/wallet and ${GLADIUSBASE}/keys. 
+
+If you want to keep your configuration even when you recreate the containers from the image you need to have persistent volumes defined for the volumes. 
+
+The docker compose file already does that so if a newer images version is used with the docker compose file the wallet, keys and content data will remain.

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -44,7 +44,7 @@ VOLUME ${GLADIUSBASE}/keys
 # controld
 EXPOSE 3001 
 # networkd
-EXPOSE 3000
+EXPOSE 5000
 EXPOSE 8080
 
 USER gladius

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -1,0 +1,50 @@
+FROM debian:stretch-slim
+
+# install curl to download gladius
+RUN apt-get update \
+  && apt-get install -y curl \
+  && rm -rf /var/lib/apt/lists/*
+
+# create gladius user
+RUN adduser --no-create-home --system gladius
+
+# setup gladius key, wallet (controld) and content (networkd) volumes
+# inside the docker container we store everything inside GLADIUSBASE
+ENV GLADIUSBASE=/gladius
+RUN mkdir -p ${GLADIUSBASE}/content \
+	&& mkdir -p ${GLADIUSBASE}/wallet \
+	&& mkdir -p ${GLADIUSBASE}/keys \
+	&& touch ${GLADIUSBASE}/gladius-networkd.toml \
+	&& touch ${GLADIUSBASE}/gladius-controld.toml
+
+# download and install gladius binaries
+ARG gladius_release
+ARG gladius_os
+ARG gladius_architecture
+RUN curl -L \
+		https://github.com/gladiusio/gladius-node/releases/download/${gladius_release}/gladius-${gladius_release}-${gladius_os}-${gladius_architecture}.tar.gz \
+		-o /tmp/gladius.tar.gz \
+  && tar -xzf /tmp/gladius.tar.gz -C /usr/local/bin/ --strip-components 2 \
+  && rm -f /tmp/gladius.tar.gz
+# download the gladius content file
+RUN curl -L https://github.com/gladiusio/gladius-node/releases/download/${gladius_release}/content.tar.gz \
+         -o /tmp/content.tar.gz \
+  && tar -xzf /tmp/content.tar.gz -C ${GLADIUSBASE}/content/ --strip-components 1 \
+  && rm -f /tmp/content.tar.gz
+# make sure all data inside the base directory belongs to the gladius user
+RUN chown -R gladius ${GLADIUSBASE} 
+
+# be sure to expose volumes for the different directories
+# inside gladius base
+VOLUME ${GLADIUSBASE}/content
+VOLUME ${GLADIUSBASE}/wallet
+VOLUME ${GLADIUSBASE}/keys
+
+# expose the ports used by the different services
+# controld
+EXPOSE 3001 
+# networkd
+EXPOSE 3000
+EXPOSE 8080
+
+USER gladius

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: ./
     ports:
-      - 3000:3000/tcp
+      - 5000:5000/tcp
       - 8080:8080/tcp
     volumes:
       - content:/gladius/content

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+volumes:
+  wallet:
+  keys:
+  content:
+
+services:
+  gladius-controld:
+    container_name: controld
+    build: 
+      context: ./
+    ports:
+      - 3001:3001/tcp
+    volumes:
+      - wallet:/gladius/wallet
+      - keys:/gladius/keys
+    entrypoint: gladius-controld
+
+  gladius-networkd:
+    container_name: networkd
+    build:
+      context: ./
+    ports:
+      - 3000:3000/tcp
+      - 8080:8080/tcp
+    volumes:
+      - content:/gladius/content
+    entrypoint: gladius-networkd


### PR DESCRIPTION
This PR contains a Dockerfile and a docker-compose.yml file which allows us to build gladius docker images based on binary releases (see the GitHub release page)

Readme: contains instructions on how to use the makefile targets provided by this pull request.
makefile: adds targets to build and push docker images based on gladius binaries with multiplatform support (not fully tested - missing a raspberry pi at home)
dockerfile: build docker image with non-privileged gladius user and exposed volumes and ports. build release and CPU architecture can be changed via build args (see readme)
docker-compose: can be used to run the docker images locally to test the build or gladius binaries (can be recycled for prod use later on)
