### PR TITLE
Fix issue with architecture detection in makefile for linux machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,29 +133,31 @@ else
 	ifeq ($(UNAME_S),Linux)
 		DOCKER_OS ?= linux
 		UNAME_P := $(shell uname -p)
+		# check if 64bit system
 		ifneq (,$(findstring amd64,$(UNAME_P)))
-    		DOCKER_ARCH ?= amd64
-    	endif
-    	ifneq (,$(findstring x86_64,$(UNAME_P)))
-    		DOCKER_ARCH ?= amd64
-    	endif
-    	ifneq (,$(findstring i686,$(UNAME_P)))
-    		DOCKER_ARCH ?= amd64
-    	endif
-    	ifneq (,$(findstring i386,$(UNAME_P)))
-    		DOCKER_ARCH ?= 386
-    	endif
-    	# arm uname -p is untested - dont have a raspberry or other arm at hand!
-    	ifneq (,$(findstring arm,$(UNAME_P)))
-    		DOCKER_ARCH ?= arm
-    	endif
-    	ifneq (,$(findstring armv7,$(UNAME_P)))
-    		DOCKER_ARCH ?= arm64
-    	endif
-    	ifneq (,$(findstring armv8,$(UNAME_P)))
-    		DOCKER_ARCH ?= arm64
-    	endif
-    endif
+			DOCKER_ARCH ?= amd64
+		endif
+		ifneq (,$(findstring x86_64,$(UNAME_P)))
+			DOCKER_ARCH ?= amd64
+		endif
+		ifneq (,$(findstring i686,$(UNAME_P)))
+			DOCKER_ARCH ?= amd64
+		endif
+		# check if 32bit system
+		ifneq (,$(findstring i386,$(UNAME_P)))
+			DOCKER_ARCH ?= 386
+		endif
+		# arm uname -p is untested - dont have a raspberry or other arm at hand!
+		ifneq (,$(findstring arm,$(UNAME_P)))
+			DOCKER_ARCH ?= arm
+		endif
+		ifneq (,$(findstring armv7,$(UNAME_P)))
+			DOCKER_ARCH ?= arm64
+		endif
+		ifneq (,$(findstring armv8,$(UNAME_P)))
+			DOCKER_ARCH ?= arm64
+		endif
+	endif
 endif
 docker_debug:
 	@echo building docker image ${DOCKER_IMAGE} with tag ${DOCKER_RELEASE}

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,12 @@ else
     	endif
     endif
 endif
-docker_image:
+docker_debug:
+	@echo building docker image ${DOCKER_IMAGE} with tag ${DOCKER_RELEASE}
+	@echo detected os: ${DOCKER_OS}
+	@echo detected arch: ${DOCKER_ARCH}
+
+docker_image: docker_debug
 	docker build --tag ${DOCKER_IMAGE}:${DOCKER_RELEASE} \
 		--build-arg gladius_release=${DOCKER_RELEASE} \
 		--build-arg gladius_os=${DOCKER_OS} \
@@ -168,7 +173,7 @@ docker_push: docker_image
 	docker push ${DOCKER_IMAGE}:${DOCKER_RELEASE}
 
 # execute local docker compose for testing
-docker_compose:
+docker_compose: docker_debug
 	# build docker compose image
 	docker-compose -p gladius -f ops/docker-compose.yml build \
 		--build-arg gladius_release=${DOCKER_RELEASE} \

--- a/Makefile
+++ b/Makefile
@@ -128,17 +128,32 @@ else
 		DOCKER_ARCH ?= amd64
 	endif
 	# if we run linux we need to check which processor arch we run on
+	# https://serverfault.com/questions/63484/linux-what-are-the-possible-values-returned-by-uname-m-and-uname-p
+	# i386 i686 x86_64 ia64 alpha amd64 arm armeb armel hppa m32r m68k mips mipsel powerpc ppc64 s390 s390x sh3 sh3eb sh4 sh4eb sparc
 	ifeq ($(UNAME_S),Linux)
 		DOCKER_OS ?= linux
-		UNAME_R := $(shell uname -r)
-		ifneq (,$(findstring amd64,$(UNAME_R)))
+		UNAME_P := $(shell uname -p)
+		ifneq (,$(findstring amd64,$(UNAME_P)))
     		DOCKER_ARCH ?= amd64
     	endif
-    	ifneq (,$(findstring i386,$(UNAME_R)))
+    	ifneq (,$(findstring x86_64,$(UNAME_P)))
+    		DOCKER_ARCH ?= amd64
+    	endif
+    	ifneq (,$(findstring i686,$(UNAME_P)))
+    		DOCKER_ARCH ?= amd64
+    	endif
+    	ifneq (,$(findstring i386,$(UNAME_P)))
     		DOCKER_ARCH ?= 386
     	endif
-    	ifneq (,$(findstring arm,$(UNAME_R)))
+    	# arm uname -p is untested - dont have a raspberry or other arm at hand!
+    	ifneq (,$(findstring arm,$(UNAME_P)))
     		DOCKER_ARCH ?= arm
+    	endif
+    	ifneq (,$(findstring armv7,$(UNAME_P)))
+    		DOCKER_ARCH ?= arm64
+    	endif
+    	ifneq (,$(findstring armv8,$(UNAME_P)))
+    		DOCKER_ARCH ?= arm64
     	endif
     endif
 endif


### PR DESCRIPTION
@alex-godwin reported an bug in the makefile which caused the cpu architecture detection not to work. I used the wrong uname parameter to check the cpu architecture which works on macos but not on linux machines.

```bash
tep 9/18 : RUN curl -L     https://github.com/gladiusio/gladius-node/releases/download/${gladius_release}/gladius-${gladius_release}-${gladius_os}-${gladius_architecture}.tar.gz     -o /tmp/gladius.tar.gz   && tar -xzf /tmp/gladius.tar.gz -C /usr/local/bin/ --strip-components 2   && rm -f /tmp/gladius.tar.gz
 ---> Running in 5d54b12d9b8d
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     9    0     9    0     0     41      0 --:--:-- --:--:-- --:--:--    41

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
The command '/bin/sh -c curl -L     https://github.com/gladiusio/gladius-node/releases/download/${gladius_release}/gladius-${gladius_release}-${gladius_os}-${gladius_architecture}.tar.gz     -o /tmp/gladius.tar.gz   && tar -xzf /tmp/gladius.tar.gz -C /usr/local/bin/ --strip-components 2   && rm -f /tmp/gladius.tar.gz' returned a non-zero code: 2
Makefile:146: recipe for target 'docker_image' failed
make: *** [docker_image] Error 2
```

I added some debug information to the make output for `docker_image` and `docker_compose` which will show the detected architecture, operating system and the image and tag to be built:

```bash
$ make docker_image
building docker image gladiusio/gladius-node with tag 0.3.0
detected os: linux
detected arch: amd64
```

I fixed this and hopefully added the correct values everywhere ;-) I admit i dont have all necessary architectures ready for testing. The reported bug should be fixed for linux (specificially ubuntu 18.04).

If you encounter the issue mentioned above you can manually specify the your cpu architecture until this pr is merged to develop and master:

```bash
# build the docker image with the gladius amd64 binaries
make docker_image DOCKER_ARCH=amd64
# run docker-compose with the gladius amd64 binaries
make docker_compose DOCKER_ARCH=amd64
```