### PR TITLE
Fix ARCH variable assignment for 32 bit ARM processors

### DIFF
--- a/installers/install.sh
+++ b/installers/install.sh
@@ -13,9 +13,9 @@ fail() {
 initArch() {
   ARCH=$(uname -m)
   case $ARCH in
-    armv5*) ARCH="armv5" ;;
-    armv6*) ARCH="armv6" ;;
-    armv7*) ARCH="armv7" ;;
+    armv5*) ARCH="arm" ;;
+    armv6*) ARCH="arm" ;;
+    armv7*) ARCH="arm" ;;
     aarch64) ARCH="arm64" ;;
     x86) ARCH="386" ;;
     x86_64) ARCH="amd64" ;;


### PR DESCRIPTION
This fixes the ARCH value assignment for 32bit arm processors.

The old values created a wrong download link for the go binary.

```
# file name is setup like this
GLADIUS_DIST="gladius-$TAG-$OS-$ARCH.tar.gz"

# with pre v8 arm processors we got a filename like
GLADIUS_DIST="gladius-0.4.0-linux-armv7.tar.gz"

# with this fix the arch value will match published releases
GLADIUS_DIST="gladius-0.4.0-linux-arm.tar.gz"
```